### PR TITLE
Add signal select

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ const server = http.createServer((req, res) => {
 
 server.listen(port, () => {
   setTimeout(() => {
-    
     // Currently you can kill ports running on TCP or UDP protocols
     kill(port, 'tcp')
       .then(console.log)
@@ -108,6 +107,8 @@ $ kill-port --port 8080
 $ kill-port 9000
 # OR you can use UDP
 $ kill-port 9000 --method udp
+# OR you can use SIGTERM
+$ kill-port --signal SIGTERM 9000
 ```
 
 You can also kill multiple ports:

--- a/cli.js
+++ b/cli.js
@@ -5,17 +5,19 @@ const kill = require('./')
 const args = require('get-them-args')(process.argv.slice(2))
 
 const verbose = args.verbose || false
-let port = args.port ? args.port.toString().split(',') : args.unknown
+const signal = args.signal || 'SIGTERM'
 const method = args.method || 'tcp'
+
+let port = args.port ? args.port.toString().split(',') : args.unknown
 
 if (!Array.isArray(port)) {
   port = [port]
 }
 
 Promise.all(port.map(current => {
-  return kill(current, method)
+  return kill(current, method, signal)
     .then((result) => {
-      console.log(`Process on port ${current} killed`)
+      console.log(`Process on ${method} port ${current} killed using signal ${signal}`)
       verbose && console.log(result)
     })
     .catch((error) => {

--- a/index.js
+++ b/index.js
@@ -2,11 +2,16 @@
 
 const sh = require('shell-exec')
 
-module.exports = function (port, method = 'tcp') {
+module.exports = function (port, method = 'tcp', signal = 'SIGKILL') {
   port = Number.parseInt(port)
+  signal = mapSignalToNumber(signal)
 
   if (!port) {
     return Promise.reject(new Error('Invalid port number provided'))
+  }
+
+  if (!signal) {
+    return Promise.reject(new Error('Invalid signal name provided'))
   }
 
   if (process.platform === 'win32') {
@@ -40,7 +45,20 @@ module.exports = function (port, method = 'tcp') {
       if (!existProccess) return Promise.reject(new Error('No process running on port'))
 
       return sh(
-        `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -9`
+        `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -${signal}`
       )
     })
+}
+
+function mapSignalToNumber(signal) {
+  const signals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGQUIT: 3,
+    SIGABRT: 6,
+    SIGKILL: 9,
+    SIGTERM: 15
+  }
+
+  return signals[signal]
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "kill-port",
-  "version": "2.0.1",
+  "name": "kill-port-nicely",
+  "version": "1.0.0",
   "description": "Kill process running on given port",
   "license": "MIT",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tiaanduplessis/kill-port.git"
+    "url": "https://https://github.com/Ghazi-Yusaf/kill-port.git"
   },
-  "homepage": "https://github.com/tiaanduplessis/kill-port",
-  "bugs": "https://github.com/tiaanduplessis/kill-port/issues",
-  "author": "Tiaan du Plessis",
+  "homepage": "https://https://github.com/Ghazi-Yusaf/kill-port",
+  "bugs": "https://github.com/Ghazi-Yusaf/kill-port/issues",
+  "author": "Tiaan du Plessis & Ghazi Yusaf",
   "bin": {
     "kill-port": "cli.js"
   },

--- a/test.js
+++ b/test.js
@@ -7,7 +7,11 @@ describe('kill-port', () => {
   })
 
   test('should throw if no port is provided', () => {
-    expect(kill()).rejects.toThrow()
+    expect(kill()).rejects.toThrow('Invalid port number provided')
+  })
+
+  test('should throw if invalid signal is provided', () => {
+    expect(kill(9999, 'tcp', 'BADSIG')).rejects.toThrow('Invalid signal name provided')
   })
 
   test('should throw if no process running on given port', () => {


### PR DESCRIPTION
# Add signal parameter

Allows users to choose the kill signal used by passing `--signal` followed by the given kill signal. The default kill signal is now `SIGTERM`.